### PR TITLE
Combined PRs

### DIFF
--- a/examples/typescript/http-client-pool/package.json
+++ b/examples/typescript/http-client-pool/package.json
@@ -25,7 +25,7 @@
     "poolifier": "^2.6.44"
   },
   "devDependencies": {
-    "@types/node": "^20.6.0",
+    "@types/node": "^20.6.1",
     "typescript": "^5.2.2"
   }
 }

--- a/examples/typescript/http-client-pool/pnpm-lock.yaml
+++ b/examples/typescript/http-client-pool/pnpm-lock.yaml
@@ -17,16 +17,16 @@ dependencies:
 
 devDependencies:
   '@types/node':
-    specifier: ^20.6.0
-    version: 20.6.0
+    specifier: ^20.6.1
+    version: 20.6.1
   typescript:
     specifier: ^5.2.2
     version: 5.2.2
 
 packages:
 
-  /@types/node@20.6.0:
-    resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
+  /@types/node@20.6.1:
+    resolution: {integrity: sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g==}
     dev: true
 
   /asynckit@0.4.0:

--- a/examples/typescript/http-server-pool/express-cluster/package.json
+++ b/examples/typescript/http-server-pool/express-cluster/package.json
@@ -29,7 +29,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^20.6.0",
     "autocannon": "^7.12.0",
-    "rollup": "^3.29.1",
+    "rollup": "^3.29.2",
     "rollup-plugin-delete": "^2.0.0",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"

--- a/examples/typescript/http-server-pool/express-cluster/package.json
+++ b/examples/typescript/http-server-pool/express-cluster/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.3",
     "@types/express": "^4.17.17",
-    "@types/node": "^20.6.0",
+    "@types/node": "^20.6.1",
     "autocannon": "^7.12.0",
     "rollup": "^3.29.2",
     "rollup-plugin-delete": "^2.0.0",

--- a/examples/typescript/http-server-pool/express-cluster/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-cluster/pnpm-lock.yaml
@@ -15,7 +15,7 @@ dependencies:
 devDependencies:
   '@rollup/plugin-typescript':
     specifier: ^11.1.3
-    version: 11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2)
+    version: 11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.2.2)
   '@types/express':
     specifier: ^4.17.17
     version: 4.17.17
@@ -26,8 +26,8 @@ devDependencies:
     specifier: ^7.12.0
     version: 7.12.0
   rollup:
-    specifier: ^3.29.1
-    version: 3.29.1
+    specifier: ^3.29.2
+    version: 3.29.2
   rollup-plugin-delete:
     specifier: ^2.0.0
     version: 2.0.0
@@ -72,7 +72,7 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@rollup/plugin-typescript@11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2):
+  /@rollup/plugin-typescript@11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.2.2):
     resolution: {integrity: sha512-8o6cNgN44kQBcpsUJTbTXMTtb87oR1O0zgP3Dxm71hrNgparap3VujgofEilTYJo+ivf2ke6uy3/E5QEaiRlDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -85,14 +85,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.29.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       resolve: 1.22.4
-      rollup: 3.29.1
+      rollup: 3.29.2
       tslib: 2.6.2
       typescript: 5.2.2
     dev: true
 
-  /@rollup/pluginutils@5.0.4(rollup@3.29.1):
+  /@rollup/pluginutils@5.0.4(rollup@3.29.2):
     resolution: {integrity: sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -104,7 +104,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.29.1
+      rollup: 3.29.2
     dev: true
 
   /@types/body-parser@1.19.2:
@@ -990,8 +990,8 @@ packages:
       del: 5.1.0
     dev: true
 
-  /rollup@3.29.1:
-    resolution: {integrity: sha512-c+ebvQz0VIH4KhhCpDsI+Bik0eT8ZFEVZEYw0cGMVqIP8zc+gnwl7iXCamTw7vzv2MeuZFZfdx5JJIq+ehzDlg==}
+  /rollup@3.29.2:
+    resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:

--- a/examples/typescript/http-server-pool/express-cluster/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-cluster/pnpm-lock.yaml
@@ -20,8 +20,8 @@ devDependencies:
     specifier: ^4.17.17
     version: 4.17.17
   '@types/node':
-    specifier: ^20.6.0
-    version: 20.6.0
+    specifier: ^20.6.1
+    version: 20.6.1
   autocannon:
     specifier: ^7.12.0
     version: 7.12.0
@@ -111,13 +111,13 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.36
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/estree@1.0.1:
@@ -127,7 +127,7 @@ packages:
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
       '@types/qs': 6.9.8
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -146,7 +146,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/http-errors@2.0.1:
@@ -165,8 +165,8 @@ packages:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
     dev: true
 
-  /@types/node@20.6.0:
-    resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
+  /@types/node@20.6.1:
+    resolution: {integrity: sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g==}
     dev: true
 
   /@types/qs@6.9.8:
@@ -181,7 +181,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/serve-static@1.15.2:
@@ -189,7 +189,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /accepts@1.3.8:

--- a/examples/typescript/http-server-pool/express-hybrid/package.json
+++ b/examples/typescript/http-server-pool/express-hybrid/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.3",
     "@types/express": "^4.17.17",
-    "@types/node": "^20.6.0",
+    "@types/node": "^20.6.1",
     "autocannon": "^7.12.0",
     "rollup": "^3.29.1",
     "rollup-plugin-delete": "^2.0.0",

--- a/examples/typescript/http-server-pool/express-hybrid/package.json
+++ b/examples/typescript/http-server-pool/express-hybrid/package.json
@@ -29,7 +29,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^20.6.1",
     "autocannon": "^7.12.0",
-    "rollup": "^3.29.1",
+    "rollup": "^3.29.2",
     "rollup-plugin-delete": "^2.0.0",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"

--- a/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
@@ -15,7 +15,7 @@ dependencies:
 devDependencies:
   '@rollup/plugin-typescript':
     specifier: ^11.1.3
-    version: 11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2)
+    version: 11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.2.2)
   '@types/express':
     specifier: ^4.17.17
     version: 4.17.17
@@ -26,8 +26,8 @@ devDependencies:
     specifier: ^7.12.0
     version: 7.12.0
   rollup:
-    specifier: ^3.29.1
-    version: 3.29.1
+    specifier: ^3.29.2
+    version: 3.29.2
   rollup-plugin-delete:
     specifier: ^2.0.0
     version: 2.0.0
@@ -72,7 +72,7 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@rollup/plugin-typescript@11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2):
+  /@rollup/plugin-typescript@11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.2.2):
     resolution: {integrity: sha512-8o6cNgN44kQBcpsUJTbTXMTtb87oR1O0zgP3Dxm71hrNgparap3VujgofEilTYJo+ivf2ke6uy3/E5QEaiRlDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -85,14 +85,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.29.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       resolve: 1.22.4
-      rollup: 3.29.1
+      rollup: 3.29.2
       tslib: 2.6.2
       typescript: 5.2.2
     dev: true
 
-  /@rollup/pluginutils@5.0.4(rollup@3.29.1):
+  /@rollup/pluginutils@5.0.4(rollup@3.29.2):
     resolution: {integrity: sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -104,7 +104,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.29.1
+      rollup: 3.29.2
     dev: true
 
   /@types/body-parser@1.19.2:
@@ -990,8 +990,8 @@ packages:
       del: 5.1.0
     dev: true
 
-  /rollup@3.29.1:
-    resolution: {integrity: sha512-c+ebvQz0VIH4KhhCpDsI+Bik0eT8ZFEVZEYw0cGMVqIP8zc+gnwl7iXCamTw7vzv2MeuZFZfdx5JJIq+ehzDlg==}
+  /rollup@3.29.2:
+    resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:

--- a/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
@@ -20,8 +20,8 @@ devDependencies:
     specifier: ^4.17.17
     version: 4.17.17
   '@types/node':
-    specifier: ^20.6.0
-    version: 20.6.0
+    specifier: ^20.6.1
+    version: 20.6.1
   autocannon:
     specifier: ^7.12.0
     version: 7.12.0
@@ -111,13 +111,13 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.36
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/estree@1.0.1:
@@ -127,7 +127,7 @@ packages:
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
       '@types/qs': 6.9.8
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -146,7 +146,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/http-errors@2.0.1:
@@ -165,8 +165,8 @@ packages:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
     dev: true
 
-  /@types/node@20.6.0:
-    resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
+  /@types/node@20.6.1:
+    resolution: {integrity: sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g==}
     dev: true
 
   /@types/qs@6.9.8:
@@ -181,7 +181,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/serve-static@1.15.2:
@@ -189,7 +189,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /accepts@1.3.8:

--- a/examples/typescript/http-server-pool/express-worker_threads/package.json
+++ b/examples/typescript/http-server-pool/express-worker_threads/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
-    "@types/node": "^20.6.0",
+    "@types/node": "^20.6.1",
     "autocannon": "^7.12.0",
     "typescript": "^5.2.2"
   }

--- a/examples/typescript/http-server-pool/express-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-worker_threads/pnpm-lock.yaml
@@ -17,8 +17,8 @@ devDependencies:
     specifier: ^4.17.17
     version: 4.17.17
   '@types/node':
-    specifier: ^20.6.0
-    version: 20.6.0
+    specifier: ^20.6.1
+    version: 20.6.1
   autocannon:
     specifier: ^7.12.0
     version: 7.12.0
@@ -43,19 +43,19 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.36
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
       '@types/qs': 6.9.8
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -82,8 +82,8 @@ packages:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
     dev: true
 
-  /@types/node@20.6.0:
-    resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
+  /@types/node@20.6.1:
+    resolution: {integrity: sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g==}
     dev: true
 
   /@types/qs@6.9.8:
@@ -98,7 +98,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/serve-static@1.15.2:
@@ -106,7 +106,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /accepts@1.3.8:

--- a/examples/typescript/http-server-pool/fastify-worker_threads/package.json
+++ b/examples/typescript/http-server-pool/fastify-worker_threads/package.json
@@ -26,7 +26,7 @@
     "poolifier": "^2.6.44"
   },
   "devDependencies": {
-    "@types/node": "^20.6.0",
+    "@types/node": "^20.6.1",
     "autocannon": "^7.12.0",
     "typescript": "^5.2.2"
   }

--- a/examples/typescript/http-server-pool/fastify-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-worker_threads/pnpm-lock.yaml
@@ -17,8 +17,8 @@ dependencies:
 
 devDependencies:
   '@types/node':
-    specifier: ^20.6.0
-    version: 20.6.0
+    specifier: ^20.6.1
+    version: 20.6.1
   autocannon:
     specifier: ^7.12.0
     version: 7.12.0
@@ -61,8 +61,8 @@ packages:
       fast-json-stringify: 5.8.0
     dev: false
 
-  /@types/node@20.6.0:
-    resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
+  /@types/node@20.6.1:
+    resolution: {integrity: sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g==}
     dev: true
 
   /abort-controller@3.0.0:

--- a/examples/typescript/websocket-server-pool/ws-cluster/package.json
+++ b/examples/typescript/websocket-server-pool/ws-cluster/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.3",
-    "@types/node": "^20.6.0",
+    "@types/node": "^20.6.1",
     "@types/ws": "^8.5.5",
     "rollup": "^3.29.1",
     "rollup-plugin-delete": "^2.0.0",

--- a/examples/typescript/websocket-server-pool/ws-cluster/package.json
+++ b/examples/typescript/websocket-server-pool/ws-cluster/package.json
@@ -27,7 +27,7 @@
     "@rollup/plugin-typescript": "^11.1.3",
     "@types/node": "^20.6.1",
     "@types/ws": "^8.5.5",
-    "rollup": "^3.29.1",
+    "rollup": "^3.29.2",
     "rollup-plugin-delete": "^2.0.0",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"

--- a/examples/typescript/websocket-server-pool/ws-cluster/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-cluster/pnpm-lock.yaml
@@ -23,7 +23,7 @@ optionalDependencies:
 devDependencies:
   '@rollup/plugin-typescript':
     specifier: ^11.1.3
-    version: 11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2)
+    version: 11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.2.2)
   '@types/node':
     specifier: ^20.6.1
     version: 20.6.1
@@ -31,8 +31,8 @@ devDependencies:
     specifier: ^8.5.5
     version: 8.5.5
   rollup:
-    specifier: ^3.29.1
-    version: 3.29.1
+    specifier: ^3.29.2
+    version: 3.29.2
   rollup-plugin-delete:
     specifier: ^2.0.0
     version: 2.0.0
@@ -66,7 +66,7 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@rollup/plugin-typescript@11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2):
+  /@rollup/plugin-typescript@11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.2.2):
     resolution: {integrity: sha512-8o6cNgN44kQBcpsUJTbTXMTtb87oR1O0zgP3Dxm71hrNgparap3VujgofEilTYJo+ivf2ke6uy3/E5QEaiRlDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -79,14 +79,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.29.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       resolve: 1.22.4
-      rollup: 3.29.1
+      rollup: 3.29.2
       tslib: 2.6.2
       typescript: 5.2.2
     dev: true
 
-  /@rollup/pluginutils@5.0.4(rollup@3.29.1):
+  /@rollup/pluginutils@5.0.4(rollup@3.29.2):
     resolution: {integrity: sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -98,7 +98,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.29.1
+      rollup: 3.29.2
     dev: true
 
   /@types/estree@1.0.1:
@@ -431,8 +431,8 @@ packages:
       del: 5.1.0
     dev: true
 
-  /rollup@3.29.1:
-    resolution: {integrity: sha512-c+ebvQz0VIH4KhhCpDsI+Bik0eT8ZFEVZEYw0cGMVqIP8zc+gnwl7iXCamTw7vzv2MeuZFZfdx5JJIq+ehzDlg==}
+  /rollup@3.29.2:
+    resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:

--- a/examples/typescript/websocket-server-pool/ws-cluster/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-cluster/pnpm-lock.yaml
@@ -25,8 +25,8 @@ devDependencies:
     specifier: ^11.1.3
     version: 11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2)
   '@types/node':
-    specifier: ^20.6.0
-    version: 20.6.0
+    specifier: ^20.6.1
+    version: 20.6.1
   '@types/ws':
     specifier: ^8.5.5
     version: 8.5.5
@@ -109,21 +109,21 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
     dev: true
 
-  /@types/node@20.6.0:
-    resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
+  /@types/node@20.6.1:
+    resolution: {integrity: sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g==}
     dev: true
 
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /aggregate-error@3.1.0:

--- a/examples/typescript/websocket-server-pool/ws-hybrid/package.json
+++ b/examples/typescript/websocket-server-pool/ws-hybrid/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.3",
-    "@types/node": "^20.6.0",
+    "@types/node": "^20.6.1",
     "@types/ws": "^8.5.5",
     "rollup": "^3.29.1",
     "rollup-plugin-delete": "^2.0.0",

--- a/examples/typescript/websocket-server-pool/ws-hybrid/package.json
+++ b/examples/typescript/websocket-server-pool/ws-hybrid/package.json
@@ -27,7 +27,7 @@
     "@rollup/plugin-typescript": "^11.1.3",
     "@types/node": "^20.6.1",
     "@types/ws": "^8.5.5",
-    "rollup": "^3.29.1",
+    "rollup": "^3.29.2",
     "rollup-plugin-delete": "^2.0.0",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"

--- a/examples/typescript/websocket-server-pool/ws-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-hybrid/pnpm-lock.yaml
@@ -23,7 +23,7 @@ optionalDependencies:
 devDependencies:
   '@rollup/plugin-typescript':
     specifier: ^11.1.3
-    version: 11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2)
+    version: 11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.2.2)
   '@types/node':
     specifier: ^20.6.1
     version: 20.6.1
@@ -31,8 +31,8 @@ devDependencies:
     specifier: ^8.5.5
     version: 8.5.5
   rollup:
-    specifier: ^3.29.1
-    version: 3.29.1
+    specifier: ^3.29.2
+    version: 3.29.2
   rollup-plugin-delete:
     specifier: ^2.0.0
     version: 2.0.0
@@ -66,7 +66,7 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@rollup/plugin-typescript@11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2):
+  /@rollup/plugin-typescript@11.1.3(rollup@3.29.2)(tslib@2.6.2)(typescript@5.2.2):
     resolution: {integrity: sha512-8o6cNgN44kQBcpsUJTbTXMTtb87oR1O0zgP3Dxm71hrNgparap3VujgofEilTYJo+ivf2ke6uy3/E5QEaiRlDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -79,14 +79,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.29.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       resolve: 1.22.4
-      rollup: 3.29.1
+      rollup: 3.29.2
       tslib: 2.6.2
       typescript: 5.2.2
     dev: true
 
-  /@rollup/pluginutils@5.0.4(rollup@3.29.1):
+  /@rollup/pluginutils@5.0.4(rollup@3.29.2):
     resolution: {integrity: sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -98,7 +98,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.29.1
+      rollup: 3.29.2
     dev: true
 
   /@types/estree@1.0.1:
@@ -431,8 +431,8 @@ packages:
       del: 5.1.0
     dev: true
 
-  /rollup@3.29.1:
-    resolution: {integrity: sha512-c+ebvQz0VIH4KhhCpDsI+Bik0eT8ZFEVZEYw0cGMVqIP8zc+gnwl7iXCamTw7vzv2MeuZFZfdx5JJIq+ehzDlg==}
+  /rollup@3.29.2:
+    resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:

--- a/examples/typescript/websocket-server-pool/ws-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-hybrid/pnpm-lock.yaml
@@ -25,8 +25,8 @@ devDependencies:
     specifier: ^11.1.3
     version: 11.1.3(rollup@3.29.1)(tslib@2.6.2)(typescript@5.2.2)
   '@types/node':
-    specifier: ^20.6.0
-    version: 20.6.0
+    specifier: ^20.6.1
+    version: 20.6.1
   '@types/ws':
     specifier: ^8.5.5
     version: 8.5.5
@@ -109,21 +109,21 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
     dev: true
 
-  /@types/node@20.6.0:
-    resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
+  /@types/node@20.6.1:
+    resolution: {integrity: sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g==}
     dev: true
 
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /aggregate-error@3.1.0:

--- a/examples/typescript/websocket-server-pool/ws-worker_threads/package.json
+++ b/examples/typescript/websocket-server-pool/ws-worker_threads/package.json
@@ -24,7 +24,7 @@
     "ws": "^8.14.1"
   },
   "devDependencies": {
-    "@types/node": "^20.6.0",
+    "@types/node": "^20.6.1",
     "@types/ws": "^8.5.5",
     "typescript": "^5.2.2"
   },

--- a/examples/typescript/websocket-server-pool/ws-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-worker_threads/pnpm-lock.yaml
@@ -22,8 +22,8 @@ optionalDependencies:
 
 devDependencies:
   '@types/node':
-    specifier: ^20.6.0
-    version: 20.6.0
+    specifier: ^20.6.1
+    version: 20.6.1
   '@types/ws':
     specifier: ^8.5.5
     version: 8.5.5
@@ -33,14 +33,14 @@ devDependencies:
 
 packages:
 
-  /@types/node@20.6.0:
-    resolution: {integrity: sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==}
+  /@types/node@20.6.1:
+    resolution: {integrity: sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g==}
     dev: true
 
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 20.6.0
+      '@types/node': 20.6.1
     dev: true
 
   /bufferutil@4.0.7:

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "mochawesome": "^7.1.3",
     "prettier": "^3.0.3",
     "release-it": "^16.1.5",
-    "rollup": "^3.29.1",
+    "rollup": "^3.29.2",
     "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-command": "^1.1.3",
     "rollup-plugin-delete": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,10 +25,10 @@ devDependencies:
     version: 4.0.0(release-it@16.1.5)
   '@rollup/plugin-terser':
     specifier: ^0.4.3
-    version: 0.4.3(rollup@3.29.1)
+    version: 0.4.3(rollup@3.29.2)
   '@rollup/plugin-typescript':
     specifier: ^11.1.3
-    version: 11.1.3(rollup@3.29.1)(typescript@5.2.2)
+    version: 11.1.3(rollup@3.29.2)(typescript@5.2.2)
   '@types/node':
     specifier: ^20.6.1
     version: 20.6.1
@@ -102,8 +102,8 @@ devDependencies:
     specifier: ^16.1.5
     version: 16.1.5
   rollup:
-    specifier: ^3.29.1
-    version: 3.29.1
+    specifier: ^3.29.2
+    version: 3.29.2
   rollup-plugin-analyzer:
     specifier: ^4.0.0
     version: 4.0.0
@@ -115,7 +115,7 @@ devDependencies:
     version: 2.0.0
   rollup-plugin-dts:
     specifier: ^6.0.2
-    version: 6.0.2(rollup@3.29.1)(typescript@5.2.2)
+    version: 6.0.2(rollup@3.29.2)(typescript@5.2.2)
   sinon:
     specifier: ^16.0.0
     version: 16.0.0
@@ -795,7 +795,7 @@ packages:
       string-template: 1.0.0
     dev: true
 
-  /@rollup/plugin-terser@0.4.3(rollup@3.29.1):
+  /@rollup/plugin-terser@0.4.3(rollup@3.29.2):
     resolution: {integrity: sha512-EF0oejTMtkyhrkwCdg0HJ0IpkcaVg1MMSf2olHb2Jp+1mnLM04OhjpJWGma4HobiDTF0WCyViWuvadyE9ch2XA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -804,13 +804,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.29.1
+      rollup: 3.29.2
       serialize-javascript: 6.0.1
       smob: 1.4.0
       terser: 5.19.4
     dev: true
 
-  /@rollup/plugin-typescript@11.1.3(rollup@3.29.1)(typescript@5.2.2):
+  /@rollup/plugin-typescript@11.1.3(rollup@3.29.2)(typescript@5.2.2):
     resolution: {integrity: sha512-8o6cNgN44kQBcpsUJTbTXMTtb87oR1O0zgP3Dxm71hrNgparap3VujgofEilTYJo+ivf2ke6uy3/E5QEaiRlDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -823,13 +823,13 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.4(rollup@3.29.1)
+      '@rollup/pluginutils': 5.0.4(rollup@3.29.2)
       resolve: 1.22.5
-      rollup: 3.29.1
+      rollup: 3.29.2
       typescript: 5.2.2
     dev: true
 
-  /@rollup/pluginutils@5.0.4(rollup@3.29.1):
+  /@rollup/pluginutils@5.0.4(rollup@3.29.2):
     resolution: {integrity: sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -841,7 +841,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.29.1
+      rollup: 3.29.2
     dev: true
 
   /@sinclair/typebox@0.27.8:
@@ -5541,7 +5541,7 @@ packages:
       del: 5.1.0
     dev: true
 
-  /rollup-plugin-dts@6.0.2(rollup@3.29.1)(typescript@5.2.2):
+  /rollup-plugin-dts@6.0.2(rollup@3.29.2)(typescript@5.2.2):
     resolution: {integrity: sha512-GYCCy9DyE5csSuUObktJBpjNpW2iLZMabNDIiAqzQWBl7l/WHzjvtAXevf8Lftk8EA920tuxeB/g8dM8MVMR6A==}
     engines: {node: '>=v16'}
     peerDependencies:
@@ -5549,14 +5549,14 @@ packages:
       typescript: ^4.5 || ^5.0
     dependencies:
       magic-string: 0.30.3
-      rollup: 3.29.1
+      rollup: 3.29.2
       typescript: 5.2.2
     optionalDependencies:
       '@babel/code-frame': 7.22.13
     dev: true
 
-  /rollup@3.29.1:
-    resolution: {integrity: sha512-c+ebvQz0VIH4KhhCpDsI+Bik0eT8ZFEVZEYw0cGMVqIP8zc+gnwl7iXCamTw7vzv2MeuZFZfdx5JJIq+ehzDlg==}
+  /rollup@3.29.2:
+    resolution: {integrity: sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #1201 build(deps-dev): bump @types/node from 20.6.0 to 20.6.1 in /examples/typescript/websocket-server-pool/ws-cluster
- Closes #1200 build(deps-dev): bump rollup from 3.29.1 to 3.29.2 in /examples/typescript/websocket-server-pool/ws-cluster
- Closes #1199 build(deps-dev): bump rollup from 3.29.1 to 3.29.2 in /examples/typescript/http-server-pool/express-cluster
- Closes #1198 build(deps-dev): bump @types/node from 20.6.0 to 20.6.1 in /examples/typescript/http-server-pool/express-cluster
- Closes #1197 build(deps-dev): bump @types/node from 20.6.0 to 20.6.1 in /examples/typescript/http-server-pool/fastify-worker_threads
- Closes #1196 build(deps-dev): bump @types/node from 20.6.0 to 20.6.1 in /examples/typescript/http-server-pool/express-worker_threads
- Closes #1195 build(deps-dev): bump @types/node from 20.6.0 to 20.6.1 in /examples/typescript/http-server-pool/express-hybrid
- Closes #1194 build(deps-dev): bump rollup from 3.29.1 to 3.29.2 in /examples/typescript/http-server-pool/express-hybrid
- Closes #1193 build(deps-dev): bump @types/node from 20.6.0 to 20.6.1 in /examples/typescript/websocket-server-pool/ws-hybrid
- Closes #1192 build(deps-dev): bump rollup from 3.29.1 to 3.29.2 in /examples/typescript/websocket-server-pool/ws-hybrid
- Closes #1191 build(deps-dev): bump rollup from 3.29.1 to 3.29.2
- Closes #1190 build(deps-dev): bump @types/node from 20.6.0 to 20.6.1 in /examples/typescript/http-client-pool
- Closes #1189 build(deps-dev): bump @types/node from 20.6.0 to 20.6.1 in /examples/typescript/websocket-server-pool/ws-worker_threads

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action