### PR TITLE
Combined PRs

### DIFF
--- a/examples/typescript/http-client-pool/package.json
+++ b/examples/typescript/http-client-pool/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "axios": "^1.6.2",
     "node-fetch": "^3.3.2",
-    "poolifier": "^3.1.7"
+    "poolifier": "^3.1.8"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/examples/typescript/http-client-pool/pnpm-lock.yaml
+++ b/examples/typescript/http-client-pool/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.3.2
     version: 3.3.2
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
 
 devDependencies:
   '@types/node':
@@ -122,8 +122,8 @@ packages:
       formdata-polyfill: 4.0.10
     dev: false
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/express-hybrid/package.json
+++ b/examples/typescript/http-server-pool/express-hybrid/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2",
-    "poolifier": "^3.1.7"
+    "poolifier": "^3.1.8"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.5",

--- a/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.18.2
     version: 4.18.2
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -1032,8 +1032,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/express-worker_threads/package.json
+++ b/examples/typescript/http-server-pool/express-worker_threads/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2",
-    "poolifier": "^3.1.7"
+    "poolifier": "^3.1.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/examples/typescript/http-server-pool/express-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-worker_threads/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.18.2
     version: 4.18.2
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
 
 devDependencies:
   '@types/express':
@@ -610,8 +610,8 @@ packages:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
     dev: false
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/fastify-hybrid/package.json
+++ b/examples/typescript/http-server-pool/fastify-hybrid/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "fastify": "^4.25.1",
     "fastify-plugin": "^4.5.1",
-    "poolifier": "^3.1.7"
+    "poolifier": "^3.1.8"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.5",

--- a/examples/typescript/http-server-pool/fastify-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-hybrid/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^4.5.1
     version: 4.5.1
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -933,8 +933,8 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/fastify-worker_threads/package.json
+++ b/examples/typescript/http-server-pool/fastify-worker_threads/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "fastify": "^4.25.1",
     "fastify-plugin": "^4.5.1",
-    "poolifier": "^3.1.7"
+    "poolifier": "^3.1.8"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/examples/typescript/http-server-pool/fastify-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-worker_threads/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^4.5.1
     version: 4.5.1
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
 
 devDependencies:
   '@types/node':
@@ -500,8 +500,8 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/smtp-client-pool/package.json
+++ b/examples/typescript/smtp-client-pool/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "nodemailer": "^6.9.7",
-    "poolifier": "^3.1.7"
+    "poolifier": "^3.1.8"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/examples/typescript/smtp-client-pool/pnpm-lock.yaml
+++ b/examples/typescript/smtp-client-pool/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^6.9.7
     version: 6.9.7
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
 
 devDependencies:
   '@types/node':
@@ -42,8 +42,8 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/websocket-server-pool/ws-cluster/package.json
+++ b/examples/typescript/websocket-server-pool/ws-cluster/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "poolifier": "^3.1.7",
+    "poolifier": "^3.1.8",
     "ws": "^8.15.1"
   },
   "devDependencies": {

--- a/examples/typescript/websocket-server-pool/ws-cluster/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-cluster/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
   ws:
     specifier: ^8.15.1
     version: 8.15.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -499,8 +499,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/websocket-server-pool/ws-hybrid/package.json
+++ b/examples/typescript/websocket-server-pool/ws-hybrid/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "poolifier": "^3.1.7",
+    "poolifier": "^3.1.8",
     "ws": "^8.15.1"
   },
   "devDependencies": {

--- a/examples/typescript/websocket-server-pool/ws-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-hybrid/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
   ws:
     specifier: ^8.15.1
     version: 8.15.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -499,8 +499,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/websocket-server-pool/ws-worker_threads/package.json
+++ b/examples/typescript/websocket-server-pool/ws-worker_threads/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "poolifier": "^3.1.7",
+    "poolifier": "^3.1.8",
     "ws": "^8.15.1"
   },
   "devDependencies": {

--- a/examples/typescript/websocket-server-pool/ws-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-worker_threads/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   poolifier:
-    specifier: ^3.1.7
-    version: 3.1.7
+    specifier: ^3.1.8
+    version: 3.1.8
   ws:
     specifier: ^8.15.1
     version: 8.15.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -59,8 +59,8 @@ packages:
     requiresBuild: true
     dev: false
 
-  /poolifier@3.1.7:
-    resolution: {integrity: sha512-dlBfj5Z3anTq54wcG2n2iyCwIFxHfRn2SCsXgCu8UEumKGJhnSWsJigQEIBAg6X5flLEBfEhN90iWgOHxzUW6w==}
+  /poolifier@3.1.8:
+    resolution: {integrity: sha512-wcB40at4TWB1srBDiC1mnhk6I8/K89baDursWNfp7YYkT3yF/h8QKXnqwjzrjZa6wqtPaTLyvmO/moOdI0NpGQ==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #1805 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/websocket-server-pool/ws-worker_threads
- Closes #1804 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/websocket-server-pool/ws-cluster
- Closes #1803 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/http-server-pool/fastify-hybrid
- Closes #1802 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/http-client-pool
- Closes #1801 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/http-server-pool/express-hybrid
- Closes #1800 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/http-server-pool/express-worker_threads
- Closes #1798 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/http-server-pool/fastify-worker_threads
- Closes #1797 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/websocket-server-pool/ws-hybrid
- Closes #1795 build(deps): bump poolifier from 3.1.7 to 3.1.8 in /examples/typescript/smtp-client-pool

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action