### PR TITLE
Combined PRs

### DIFF
--- a/examples/typescript/http-server-pool/express-cluster/package.json
+++ b/examples/typescript/http-server-pool/express-cluster/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2",
-    "poolifier": "^3.1.20"
+    "poolifier": "^3.1.21"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/examples/typescript/http-server-pool/express-cluster/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-cluster/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.18.2
     version: 4.18.2
   poolifier:
-    specifier: ^3.1.20
-    version: 3.1.20
+    specifier: ^3.1.21
+    version: 3.1.21
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -1061,8 +1061,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.20:
-    resolution: {integrity: sha512-UmT6eHbCwb22J+8cDtcjPJaDc7CMpNaTtJ+7QArTOo6F1DMApXBJny8qGllhwYpAscJT6VoMVoQlN1EHksdQOw==}
+  /poolifier@3.1.21:
+    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/express-hybrid/package.json
+++ b/examples/typescript/http-server-pool/express-hybrid/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2",
-    "poolifier": "^3.1.20"
+    "poolifier": "^3.1.21"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.18.2
     version: 4.18.2
   poolifier:
-    specifier: ^3.1.20
-    version: 3.1.20
+    specifier: ^3.1.21
+    version: 3.1.21
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -1061,8 +1061,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.20:
-    resolution: {integrity: sha512-UmT6eHbCwb22J+8cDtcjPJaDc7CMpNaTtJ+7QArTOo6F1DMApXBJny8qGllhwYpAscJT6VoMVoQlN1EHksdQOw==}
+  /poolifier@3.1.21:
+    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/fastify-cluster/package.json
+++ b/examples/typescript/http-server-pool/fastify-cluster/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "fastify": "^4.26.1",
-    "poolifier": "^3.1.20"
+    "poolifier": "^3.1.21"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/examples/typescript/http-server-pool/fastify-cluster/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-cluster/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.26.1
     version: 4.26.1
   poolifier:
-    specifier: ^3.1.20
-    version: 3.1.20
+    specifier: ^3.1.21
+    version: 3.1.21
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -936,8 +936,8 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
-  /poolifier@3.1.20:
-    resolution: {integrity: sha512-UmT6eHbCwb22J+8cDtcjPJaDc7CMpNaTtJ+7QArTOo6F1DMApXBJny8qGllhwYpAscJT6VoMVoQlN1EHksdQOw==}
+  /poolifier@3.1.21:
+    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/fastify-hybrid/package.json
+++ b/examples/typescript/http-server-pool/fastify-hybrid/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "fastify": "^4.26.1",
     "fastify-plugin": "^4.5.1",
-    "poolifier": "^3.1.20"
+    "poolifier": "^3.1.21"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/examples/typescript/http-server-pool/fastify-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-hybrid/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^4.5.1
     version: 4.5.1
   poolifier:
-    specifier: ^3.1.20
-    version: 3.1.20
+    specifier: ^3.1.21
+    version: 3.1.21
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -943,8 +943,8 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
-  /poolifier@3.1.20:
-    resolution: {integrity: sha512-UmT6eHbCwb22J+8cDtcjPJaDc7CMpNaTtJ+7QArTOo6F1DMApXBJny8qGllhwYpAscJT6VoMVoQlN1EHksdQOw==}
+  /poolifier@3.1.21:
+    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/fastify-worker_threads/package.json
+++ b/examples/typescript/http-server-pool/fastify-worker_threads/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "fastify": "^4.26.1",
     "fastify-plugin": "^4.5.1",
-    "poolifier": "^3.1.20"
+    "poolifier": "^3.1.21"
   },
   "devDependencies": {
     "@types/node": "^20.11.20",

--- a/examples/typescript/http-server-pool/fastify-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-worker_threads/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^4.5.1
     version: 4.5.1
   poolifier:
-    specifier: ^3.1.20
-    version: 3.1.20
+    specifier: ^3.1.21
+    version: 3.1.21
 
 devDependencies:
   '@types/node':
@@ -510,8 +510,8 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
-  /poolifier@3.1.20:
-    resolution: {integrity: sha512-UmT6eHbCwb22J+8cDtcjPJaDc7CMpNaTtJ+7QArTOo6F1DMApXBJny8qGllhwYpAscJT6VoMVoQlN1EHksdQOw==}
+  /poolifier@3.1.21:
+    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/websocket-server-pool/ws-worker_threads/package.json
+++ b/examples/typescript/websocket-server-pool/ws-worker_threads/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "poolifier": "^3.1.20",
+    "poolifier": "^3.1.21",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/examples/typescript/websocket-server-pool/ws-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-worker_threads/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   poolifier:
-    specifier: ^3.1.20
-    version: 3.1.20
+    specifier: ^3.1.21
+    version: 3.1.21
   ws:
     specifier: ^8.16.0
     version: 8.16.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -59,8 +59,8 @@ packages:
     requiresBuild: true
     dev: false
 
-  /poolifier@3.1.20:
-    resolution: {integrity: sha512-UmT6eHbCwb22J+8cDtcjPJaDc7CMpNaTtJ+7QArTOo6F1DMApXBJny8qGllhwYpAscJT6VoMVoQlN1EHksdQOw==}
+  /poolifier@3.1.21:
+    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #2003 build(deps): bump poolifier from 3.1.20 to 3.1.21 in /examples/typescript/http-server-pool/fastify-hybrid
- Closes #2001 build(deps): bump poolifier from 3.1.20 to 3.1.21 in /examples/typescript/http-server-pool/fastify-worker_threads
- Closes #2000 build(deps): bump poolifier from 3.1.20 to 3.1.21 in /examples/typescript/http-server-pool/express-hybrid
- Closes #1999 build(deps): bump poolifier from 3.1.20 to 3.1.21 in /examples/typescript/http-server-pool/express-cluster
- Closes #1998 build(deps): bump poolifier from 3.1.20 to 3.1.21 in /examples/typescript/http-server-pool/fastify-cluster
- Closes #1997 build(deps): bump poolifier from 3.1.20 to 3.1.21 in /examples/typescript/websocket-server-pool/ws-worker_threads

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action