### PR TITLE
Combined PRs

### DIFF
--- a/examples/typescript/http-client-pool/package.json
+++ b/examples/typescript/http-client-pool/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "axios": "^1.6.8",
     "node-fetch": "^3.3.2",
-    "poolifier": "^3.1.21"
+    "poolifier": "^3.1.22"
   },
   "devDependencies": {
     "@types/node": "^20.11.28",

--- a/examples/typescript/http-client-pool/pnpm-lock.yaml
+++ b/examples/typescript/http-client-pool/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.3.2
     version: 3.3.2
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
 
 devDependencies:
   '@types/node':
@@ -122,8 +122,8 @@ packages:
       formdata-polyfill: 4.0.10
     dev: false
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/express-cluster/package.json
+++ b/examples/typescript/http-server-pool/express-cluster/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.3",
-    "poolifier": "^3.1.21"
+    "poolifier": "^3.1.22"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/examples/typescript/http-server-pool/express-cluster/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-cluster/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.18.3
     version: 4.18.3
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -1061,8 +1061,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/express-hybrid/package.json
+++ b/examples/typescript/http-server-pool/express-hybrid/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.3",
-    "poolifier": "^3.1.21"
+    "poolifier": "^3.1.22"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-hybrid/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.18.3
     version: 4.18.3
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -1061,8 +1061,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/express-worker_threads/package.json
+++ b/examples/typescript/http-server-pool/express-worker_threads/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.3",
-    "poolifier": "^3.1.21"
+    "poolifier": "^3.1.22"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/examples/typescript/http-server-pool/express-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/express-worker_threads/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.18.3
     version: 4.18.3
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
 
 devDependencies:
   '@types/express':
@@ -639,8 +639,8 @@ packages:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
     dev: false
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/fastify-cluster/package.json
+++ b/examples/typescript/http-server-pool/fastify-cluster/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "fastify": "^4.26.2",
-    "poolifier": "^3.1.21"
+    "poolifier": "^3.1.22"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/examples/typescript/http-server-pool/fastify-cluster/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-cluster/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^4.26.2
     version: 4.26.2
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -936,8 +936,8 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/fastify-hybrid/package.json
+++ b/examples/typescript/http-server-pool/fastify-hybrid/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "fastify": "^4.26.2",
     "fastify-plugin": "^4.5.1",
-    "poolifier": "^3.1.21"
+    "poolifier": "^3.1.22"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/examples/typescript/http-server-pool/fastify-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-hybrid/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^4.5.1
     version: 4.5.1
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -943,8 +943,8 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/http-server-pool/fastify-worker_threads/package.json
+++ b/examples/typescript/http-server-pool/fastify-worker_threads/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "fastify": "^4.26.2",
     "fastify-plugin": "^4.5.1",
-    "poolifier": "^3.1.21"
+    "poolifier": "^3.1.22"
   },
   "devDependencies": {
     "@types/node": "^20.11.28",

--- a/examples/typescript/http-server-pool/fastify-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/http-server-pool/fastify-worker_threads/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^4.5.1
     version: 4.5.1
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
 
 devDependencies:
   '@types/node':
@@ -510,8 +510,8 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/smtp-client-pool/package.json
+++ b/examples/typescript/smtp-client-pool/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "nodemailer": "^6.9.12",
-    "poolifier": "^3.1.21"
+    "poolifier": "^3.1.22"
   },
   "devDependencies": {
     "@types/node": "^20.11.28",

--- a/examples/typescript/smtp-client-pool/pnpm-lock.yaml
+++ b/examples/typescript/smtp-client-pool/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^6.9.12
     version: 6.9.12
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
 
 devDependencies:
   '@types/node':
@@ -42,8 +42,8 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/websocket-server-pool/ws-cluster/package.json
+++ b/examples/typescript/websocket-server-pool/ws-cluster/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "poolifier": "^3.1.21",
+    "poolifier": "^3.1.22",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/examples/typescript/websocket-server-pool/ws-cluster/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-cluster/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
   ws:
     specifier: ^8.16.0
     version: 8.16.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -499,8 +499,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/websocket-server-pool/ws-hybrid/package.json
+++ b/examples/typescript/websocket-server-pool/ws-hybrid/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "poolifier": "^3.1.21",
+    "poolifier": "^3.1.22",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/examples/typescript/websocket-server-pool/ws-hybrid/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-hybrid/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
   ws:
     specifier: ^8.16.0
     version: 8.16.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -499,8 +499,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false

--- a/examples/typescript/websocket-server-pool/ws-worker_threads/package.json
+++ b/examples/typescript/websocket-server-pool/ws-worker_threads/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "poolifier": "^3.1.21",
+    "poolifier": "^3.1.22",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/examples/typescript/websocket-server-pool/ws-worker_threads/pnpm-lock.yaml
+++ b/examples/typescript/websocket-server-pool/ws-worker_threads/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   poolifier:
-    specifier: ^3.1.21
-    version: 3.1.21
+    specifier: ^3.1.22
+    version: 3.1.22
   ws:
     specifier: ^8.16.0
     version: 8.16.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -59,8 +59,8 @@ packages:
     requiresBuild: true
     dev: false
 
-  /poolifier@3.1.21:
-    resolution: {integrity: sha512-6bWowXA6RedrnEypsc+5g1qbv+m7KgiY2H/Jf+iGIjbDr6/46voj7Ap6NepzknOGCB2JmU13bvAbyQkD2fvFGw==}
+  /poolifier@3.1.22:
+    resolution: {integrity: sha512-Md/Dsz5MZVKX515MixI2i05e/mF8137dqdT09X+U+TqLxP6FajndWgoCFZe7XfpRUdt7FwmUuatoS6fIFZZqaA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.6.0'}
     requiresBuild: true
     dev: false


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #2075 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/http-server-pool/express-hybrid
- Closes #2074 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/smtp-client-pool
- Closes #2073 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/http-server-pool/express-worker_threads
- Closes #2072 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/http-server-pool/fastify-cluster
- Closes #2071 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/http-server-pool/fastify-hybrid
- Closes #2070 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/websocket-server-pool/ws-cluster
- Closes #2069 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/websocket-server-pool/ws-hybrid
- Closes #2068 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/http-client-pool
- Closes #2067 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/http-server-pool/express-cluster
- Closes #2066 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/websocket-server-pool/ws-worker_threads
- Closes #2065 build(deps): bump poolifier from 3.1.21 to 3.1.22 in /examples/typescript/http-server-pool/fastify-worker_threads

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action