### PR TITLE
test: relax destroy timeout assertion

### DIFF
--- a/tests/pools/abstract-pool.test.mjs
+++ b/tests/pools/abstract-pool.test.mjs
@@ -1565,36 +1565,45 @@ describe('Abstract pool test suite', () => {
     )
   })
 
-  it('Verify that destroy() waits until the tasks finished timeout is reached', async () => {
-    const tasksFinishedTimeout = 1000
-    const pool = new FixedThreadPool(
-      numberOfWorkers,
-      './tests/worker-files/thread/asyncWorker.mjs',
-      {
+  for (const { PoolClass, workerFilePath, workerType } of [
+    {
+      PoolClass: FixedClusterPool,
+      workerFilePath: './tests/worker-files/cluster/asyncWorker.cjs',
+      workerType: WorkerTypes.cluster,
+    },
+    {
+      PoolClass: FixedThreadPool,
+      workerFilePath: './tests/worker-files/thread/asyncWorker.mjs',
+      workerType: WorkerTypes.thread,
+    },
+  ]) {
+    it(`Verify that destroy() waits until the tasks finished timeout is reached in a ${workerType} pool`, async () => {
+      const tasksFinishedTimeout = 1000
+      const pool = new PoolClass(numberOfWorkers, workerFilePath, {
         enableTasksQueue: true,
         tasksQueueOptions: { tasksFinishedTimeout },
-      }
-    )
-    const maxMultiplier = 4
-    let tasksFinished = 0
-    for (const workerNode of pool.workerNodes) {
-      workerNode.on('taskFinished', () => {
-        ++tasksFinished
       })
-    }
-    for (let i = 0; i < numberOfWorkers * maxMultiplier; i++) {
-      pool.execute()
-    }
-    expect(pool.info.queuedTasks).toBeGreaterThan(0)
-    const startTime = performance.now()
-    await pool.destroy()
-    const elapsedTime = performance.now() - startTime
-    expect(tasksFinished).toBe(0)
-    // Worker kill message response timeout is 1000ms
-    expect(elapsedTime).toBeLessThanOrEqual(
-      tasksFinishedTimeout + 1000 * tasksFinished + 1000
-    )
-  })
+      const maxMultiplier = 4
+      let tasksFinished = 0
+      for (const workerNode of pool.workerNodes) {
+        workerNode.on('taskFinished', () => {
+          ++tasksFinished
+        })
+      }
+      for (let i = 0; i < numberOfWorkers * maxMultiplier; i++) {
+        pool.execute()
+      }
+      expect(pool.info.queuedTasks).toBeGreaterThan(0)
+      const startTime = performance.now()
+      await pool.destroy()
+      const elapsedTime = performance.now() - startTime
+      expect(tasksFinished).toBe(0)
+      // Allow task timeout, 1000ms per kill response, and 100ms scheduling slack.
+      expect(elapsedTime).toBeLessThanOrEqual(
+        tasksFinishedTimeout + 1000 * tasksFinished + 1100
+      )
+    })
+  }
 
   it('Verify that pool asynchronous resource track tasks execution', async () => {
     let taskAsyncId


### PR DESCRIPTION
## Summary
- relax the destroy timeout upper bound from `+ 1000` to `+ 1100`
- keep the formula explicit with a precise one-line comment
- run the timeout assertion for both `FixedClusterPool` and `FixedThreadPool`

## Verification
- `node --check tests/pools/abstract-pool.test.mjs`
- `git diff --check -- tests/pools/abstract-pool.test.mjs`
- `corepack pnpm exec eslint tests/pools/abstract-pool.test.mjs`
- `corepack pnpm exec vitest run tests/pools/abstract-pool.test.mjs -t 'destroy\\(\\) waits'`
  - passed 3 tests, including cluster and thread pools
- `corepack pnpm build --environment SOURCEMAP:false && CI=1 corepack pnpm exec vitest run`
  - passed 20 files, 286 tests, 4 skipped

Note: plain `corepack pnpm test` is not usable in this local Volta setup because the package script invokes `pnpm` and Volta has no `pnpm` executable installed; the equivalent build + vitest commands above were run directly via Corepack.
