### PR TITLE
ci: use GitHub token for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
     branches: [master]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number
+        required: true
+        type: string
+      head_ref:
+        description: Pull request head branch
+        required: true
+        type: string
+      base_ref:
+        description: Pull request base branch
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -69,6 +83,9 @@ jobs:
       - name: SonarCloud Code Analysis
         if: ${{ steps.sonar-token.outputs.available == 'true' && github.repository == 'poolifier/poolifier' && matrix.os == 'ubuntu-latest' && matrix.node == '22.x' }}
         uses: sonarsource/sonarqube-scan-action@v8.2
+        with:
+          args: >-
+            ${{ github.event_name == 'workflow_dispatch' && format('-Dsonar.pullrequest.key={0} -Dsonar.pullrequest.branch={1} -Dsonar.pullrequest.base={2}', inputs.pull_request, inputs.head_ref, inputs.base_ref) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,13 +35,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
+          pull_request=$(jq -r '.number' <<< "$RELEASE_PR")
           head_ref=$(jq -r '.headBranchName' <<< "$RELEASE_PR")
+          base_ref=$(jq -r '.baseBranchName' <<< "$RELEASE_PR")
+
           gh workflow run ci.yml \
             --repo "${{ github.repository }}" \
             --ref "$head_ref" \
-            --field pull_request="$(jq -r '.number' <<< "$RELEASE_PR")" \
-            --field head_ref="$head_ref" \
-            --field base_ref="$(jq -r '.baseBranchName' <<< "$RELEASE_PR")"
+            --raw-field pull_request="$pull_request" \
+            --raw-field head_ref="$head_ref" \
+            --raw-field base_ref="$base_ref"
 
   build-release:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
 
     permissions:
       contents: write
+      issues: write
       pull-requests: write
 
     outputs:
@@ -24,7 +25,7 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.WORKFLOW_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'poolifier/poolifier'
 
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -27,6 +28,20 @@ jobs:
         with:
           config-file: .github/release-please/config.json
           manifest-file: .github/release-please/manifest.json
+
+      - name: Dispatch CI for release pull request
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
+        run: |
+          head_ref=$(jq -r '.headBranchName' <<< "$RELEASE_PR")
+          gh workflow run ci.yml \
+            --repo "${{ github.repository }}" \
+            --ref "$head_ref" \
+            --field pull_request="$(jq -r '.number' <<< "$RELEASE_PR")" \
+            --field head_ref="$head_ref" \
+            --field base_ref="$(jq -r '.baseBranchName' <<< "$RELEASE_PR")"
 
   build-release:
     needs: release-please


### PR DESCRIPTION
## Summary

- rely on Release Please's built-in `GITHUB_TOKEN` default, without a token input or custom secret
- dispatch CI explicitly on each created or updated release pull request
- preserve SonarCloud pull-request analysis by forwarding the PR number, head, and base refs
- grant only the additional `actions: write` and `issues: write` permissions required by this flow

## Verification

- `prettier --check .github/workflows/ci.yml .github/workflows/release-please.yml`
- `git diff --check`
- repository workflow permissions: `write`; pull-request creation and approval: enabled

## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows conventional commits.
- [x] Tests are not applicable to this workflow-only change.
- [x] No user-facing documentation change is required.
- [ ] No linked issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No