### PR TITLE
fix(benchmark): correct Bencher reporting and benchmark failures

### DIFF
--- a/.github/workflows/internal-benchmark.yml
+++ b/.github/workflows/internal-benchmark.yml
@@ -33,9 +33,17 @@ jobs:
         run: pnpm install --ignore-scripts --frozen-lockfile
       - uses: bencherdev/bencher@main
       - name: Run production benchmark
+        run: pnpm benchmark:tinybench:prod
+      - name: Publish benchmark
+        shell: bash
         run: |
+          args=()
+          if [[ "$GITHUB_REF" != refs/heads/master ]]; then
+            args+=(--dry-run)
+          fi
           bencher run \
-          --branch master \
+          "${args[@]}" \
+          --branch "$GITHUB_REF_NAME" \
           --threshold-measure latency \
           --threshold-test t_test \
           --threshold-max-sample-size 64 \
@@ -48,6 +56,4 @@ jobs:
           --threshold-upper-boundary _ \
           --thresholds-reset \
           --file benchmark-report.json \
-          --err \
-          --github-actions ${{ secrets.GITHUB_TOKEN }} \
-          "pnpm benchmark:tinybench:prod"
+          --err

--- a/benchmarks/benchmarks-utils.mjs
+++ b/benchmarks/benchmarks-utils.mjs
@@ -68,7 +68,7 @@ export const runPoolifierBenchmarkTinyBench = async (
   const bmfResults = {}
   let pool
   try {
-    const bench = new Bench()
+    const bench = new Bench({ throws: true })
     pool = buildPoolifierPool(workerType, poolType, poolSize)
 
     for (const workerChoiceStrategy of Object.values(WorkerChoiceStrategies)) {
@@ -139,29 +139,25 @@ export const runPoolifierBenchmarkTinyBench = async (
     console.table(bench.table())
 
     for (const task of tasks) {
-      if (
-        task.result?.state === 'completed' ||
-        task.result?.state === 'aborted-with-statistics'
-      ) {
-        bmfResults[task.name] = {
-          latency: {
-            lower_value: task.result.latency.mean - task.result.latency.sd,
-            upper_value: task.result.latency.mean + task.result.latency.sd,
-            value: task.result.latency.mean,
-          },
-          throughput: {
-            lower_value:
-              task.result.throughput.mean - task.result.throughput.sd,
-            upper_value:
-              task.result.throughput.mean + task.result.throughput.sd,
-            value: task.result.throughput.mean,
-          },
-        }
+      if (task.result?.state !== 'completed') {
+        throw new Error(`Benchmark did not complete: ${task.name}`)
+      }
+      bmfResults[task.name] = {
+        latency: {
+          // Tinybench reports milliseconds; Bencher latency uses nanoseconds.
+          lower_value:
+            (task.result.latency.mean - task.result.latency.sd) * 1e6,
+          upper_value:
+            (task.result.latency.mean + task.result.latency.sd) * 1e6,
+          value: task.result.latency.mean * 1e6,
+        },
+        throughput: {
+          lower_value: task.result.throughput.mean - task.result.throughput.sd,
+          upper_value: task.result.throughput.mean + task.result.throughput.sd,
+          value: task.result.throughput.mean,
+        },
       }
     }
-    return bmfResults
-  } catch (error) {
-    console.error(error)
     return bmfResults
   } finally {
     if (pool != null) {

--- a/benchmarks/benchmarks-utils.mjs
+++ b/benchmarks/benchmarks-utils.mjs
@@ -1,5 +1,5 @@
 import { strictEqual } from 'node:assert'
-import { Bench } from 'tinybench'
+import { Bench, mToNs } from 'tinybench'
 
 import {
   DynamicClusterPool,
@@ -145,11 +145,9 @@ export const runPoolifierBenchmarkTinyBench = async (
       bmfResults[task.name] = {
         latency: {
           // Tinybench reports milliseconds; Bencher latency uses nanoseconds.
-          lower_value:
-            (task.result.latency.mean - task.result.latency.sd) * 1e6,
-          upper_value:
-            (task.result.latency.mean + task.result.latency.sd) * 1e6,
-          value: task.result.latency.mean * 1e6,
+          lower_value: mToNs(task.result.latency.mean - task.result.latency.sd),
+          upper_value: mToNs(task.result.latency.mean + task.result.latency.sd),
+          value: mToNs(task.result.latency.mean),
         },
         throughput: {
           lower_value: task.result.throughput.mean - task.result.throughput.sd,


### PR DESCRIPTION
## Summary

Port of poolifier-web-worker#176 to Poolifier (Node.js/pnpm project):

- `benchmarks/benchmarks-utils.mjs`: `Bench({ throws: true })`, reject any non-`completed` task instead of silently skipping or accepting `aborted-with-statistics`, convert Tinybench latency ms to Bencher ns (`* 1e6`), propagate errors instead of returning partial results (pool still destroyed in `finally`). Key order adapted to this repo's `perfectionist/sort-objects` lint rule; semantics identical.
- `.github/workflows/internal-benchmark.yml`: split benchmark execution (`pnpm benchmark:tinybench:prod`, which writes `benchmark-report.json` under CI and exits non-zero on failure) from `bencher run` publication; `--branch "$GITHUB_REF_NAME"` with `--dry-run` off `master`; drop `--github-actions` PR-comment flag (push/dispatch-only workflow).
- `renovate.json` change from #176 (npm updates in `deno.json`, Deno 24h age policy) not ported: no `deno.json` here, and npm minimum-release-age is already covered by `security:minimumReleaseAgeNpm`.

Historical warning (same as #176): stored latency history is ms labeled as ns; corrected ns reports may trigger artificial latency alerts until history is migrated. Throughput units unchanged; thresholds and `self-hosted` testbed unchanged.

## Validation of #176 changes

- `throws` exists in tinybench 6.1.3 (`node_modules/tinybench/dist/index.d.ts`); strict `completed`-only check rejects `aborted`/`errored` results instead of publishing partial data.
- `bench.mjs` writes `benchmark-report.json` under `CI` and exits 1 on error, so the split run/publish steps preserve failure propagation previously provided by `bencher run --err "..."`.
- `workflow_dispatch` + `push: master` retained; dry-run scoping and dynamic branch match the source PR.
- Removing `--github-actions` is safe here: no PR context in this workflow, and it drops the `GITHUB_TOKEN` requirement.
- Renovate rule verified as Deno-only; correctly out of scope for this repo.

## Verification (this repo)

- `prettier --check` on both files
- `eslint benchmarks/benchmarks-utils.mjs`
- `node --check benchmarks/benchmarks-utils.mjs`
- `git diff --check`

## PR Checklist

- [x] Please add a description of your changes.
- [x] Please ensure title follows conventional commits.
- [x] Tests not applicable (benchmark reporting/workflow-only change; full benchmark requires self-hosted runner).
- [x] No user-facing documentation change required.
- [x] Port of poolifier/poolifier-web-worker#176.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No